### PR TITLE
chore: only process notifications if there is a report

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -89,7 +89,7 @@ runs:
 
     - name: Upload Trivy Report as PR Comment and parse Critical vulnerabilities
       id: trivy_report_notification
-      if: ${{ inputs.github-token && github.event_name == 'pull_request' }}
+      if: ${{ inputs.github-token && github.event_name == 'pull_request' && steps.trivy_artifact_upload.outputs.artifact-url }}
       uses: actions/github-script@v7
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}


### PR DESCRIPTION
There are a handful of problems with this current implementation of trivy.

According to the docs, we should cache the db to prevent the rate limiting related errors we see very often: https://github.com/aquasecurity/trivy-action?tab=readme-ov-file#updating-caches-in-the-default-branch. 

The code as-is doesn't handle errors and proceeds with trying to process a file that doesn't exist. You can see that here: https://github.com/stordco/tenant_service/actions/runs/11374301747/job/31642696809?pr=115.

- trivy returns a rate limiting error trying to load the db
- upload artifact skips just noops and continues
- our script 💣 because the file doesn't exist

This only fixes one part of the problem, but will at least stop making it look like PRs are failing 😅 