### PR TITLE
fix: update trivy-action version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
 
     - name: Run Trivy vulnerability scanner in ${{ inputs.scan-type }} mode
       id: trivy_scan
-      uses: aquasecurity/trivy-action@0.23.0
+      uses: aquasecurity/trivy-action@0.28.0
       env:
         TRIVY_SKIP_DB_UPDATE: ${{ inputs.update-db == 'false' && 'true' || 'false' }}
       with:


### PR DESCRIPTION
Updates to the latest released version of `trivy-action`, which supports loading the DB cache.